### PR TITLE
Minor updates to homepage including date format

### DIFF
--- a/_includes/schedule-date-cards.html
+++ b/_includes/schedule-date-cards.html
@@ -31,7 +31,7 @@
       </div>
       <div class="details">
         <h2 class="date-card-title">Sprints</h2>
-        <p>Team up to contribute to Django!</p>
+        <p>Team up to contribute to Django projects!</p>
       </div>
     </a>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,7 +9,7 @@ layout: base
 
       <div class="event-info-detail">
         <strong
-          class="event-info-date">May 29th - June 2nd 2023</strong>
+          class="event-info-date">29th May - 2nd June 2023</strong>
 
         <span
           class="subheading event-info-location">
@@ -60,7 +60,7 @@ layout: base
     <div class="column">
       <div class="card">
       <p>This is the 15th edition of the Conference and it is organized by a team made up of Django practitioners from all levels. We welcome people from all over the world.</p>
-      <p>Our conference seeks to educate and develop new skills, best practices and ideas for the benefit of attendees, developers, speakers and everyone in our global Django Community, not least those watching the talks online.</p>
+      <p>Our conference seeks to educate and develop new skills, best practices and ideas for the benefit of attendees, developers, speakers and everyone in our global Django Community.</p>
       </div>
     </div>
     {% comment %}


### PR DESCRIPTION
Some minor homepage updates:
- change date format from US to UK
- remove reference to attendees watching online
- update sprints description