### PR TITLE
Replace donate/donation with contribution

### DIFF
--- a/_pages/faqs.html
+++ b/_pages/faqs.html
@@ -109,7 +109,7 @@ title: Frequently Asked Questions
         <p><em>More information is on our <a href="{% link _pages/sponsors-information.md %}">Become a Sponsor</a> page. Sponsorship signups for 2022 are now closed.</em></p>
         {% comment %}<ul>
           <li>Can I sign up as a sponsor for DjangoCon US 2022?</li>
-          <li>Can I sign up as a sponsor for <a href="{% link _pages/opportunity-grants.md %}#how-to-donate">Opportunity Grants</a>?</li>
+          <li>Can I sign up as a sponsor for <a href="{% link _pages/opportunity-grants.md %}">Opportunity Grants</a>?</li>
           <li>Are any of the sponsors <a href="/job-board/">hiring</a>?</li>
         </ul>{% endcomment %}
       </section>

--- a/_pages/opportunity-grants.md
+++ b/_pages/opportunity-grants.md
@@ -11,10 +11,10 @@ title: Opportunity Grants
 
 DjangoCon Europe 2023 is pleased to offer grants for those who might otherwise not be able to attend.
 
-## Sponsorship and donations
+## Sponsorship and contributions
 Your organisation can help increase diversity at DjangoCon Europe by contributing to the opportunity grant fund. Please check out our <a href="/sponsors/information/">sponsorship information page</a> for more information.
 
-You can also donate by purchasing a supporter ticket which will allow us to allocate extra funds to providing cheaper or free tickets to those who would not otherwise be able to afford to attend.
+You can also contribute by purchasing a supporter ticket which will allow us to allocate extra funds to providing cheaper or free tickets to those who would not otherwise be able to afford to attend.
 
 ## Eligibility
 

--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -13,7 +13,7 @@ permalink: /sponsors/
   <div class="row column v-pad-bottom">
     <div class="medium-6 large-7 column">
       <p class="lead">
-        DjangoCon Europe is only possible through the generosity of the organizations and businesses on this page. Their donations make it possible for us to provide opportunity grants to speakers and attendees, record all talks, host sprints, and feed everyone for five days. Thank you for your support!
+        DjangoCon Europe is only possible through the generosity of the organizations and businesses on this page. Their contributions make it possible for us to provide opportunity grants to speakers and attendees, record all talks, host sprints, and feed everyone for five days. Thank you for your support!
       </p>
     </div>
     <div class="medium-5 large-4 column">


### PR DESCRIPTION
While I don't think it's particularly likely anyone would read "donation" and think "*charitable* donation", "contribution" has far less ambiguity

(Removed an obsolete fragment in the process)