### PR TITLE
fix: only show more news when more than 6 articles, GH-20

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -136,11 +136,13 @@ layout: base
     {% endfor %}
   </div>
 
+  {% if visible_posts.size > 12 %}
   <div class="row v-pad-top">
     <div class="medium-4 column medium-centered text-center">
       <a class="button" href="/news/">Read More News</a>
     </div>
   </div>
+  {% endif %}
 </section>
 {% endif %}
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -136,7 +136,7 @@ layout: base
     {% endfor %}
   </div>
 
-  {% if visible_posts.size > 12 %}
+  {% if visible_posts.size > 6 %}
   <div class="row v-pad-top">
     <div class="medium-4 column medium-centered text-center">
       <a class="button" href="/news/">Read More News</a>


### PR DESCRIPTION
It is currently set show a max of 12 posts here: https://github.com/djangocon/2023.djangocon.eu/blob/main/_layouts/home.html#L123

So I set the button to appear when there are more than 12.

However, I think 12 might be too many news items.