### PR TITLE
Add an attendee-info page with shortcut links

### DIFF
--- a/_pages/attendee-info.md
+++ b/_pages/attendee-info.md
@@ -1,0 +1,13 @@
+---
+description: Attendee Information
+heading: Practical Information for Attendees
+layout: default
+permalink: /attendee-info/
+title: Attendee Information
+---
+
+- [Schedule](https://pretalx.com/djangocon-europe-2023/schedule/)
+- [Catering menus](/catering-menus)
+- [Discord](https://discord.com/channels/1064863916682924172/1064863916682924176)
+    - [Joining for the first time?](https://discord.gg/YKNMUCuNKv)
+- [Code of Conduct](/conduct)


### PR DESCRIPTION
Fixes #98 

There may be other links we want to add, but these are the main ones I can think of for now